### PR TITLE
a small mistake in the parameter naming

### DIFF
--- a/include/flecs/private/hashmap.h
+++ b/include/flecs/private/hashmap.h
@@ -48,8 +48,8 @@ void _flecs_hashmap_init(
     ecs_compare_action_t compare,
     ecs_allocator_t *allocator);
 
-#define flecs_hashmap_init(hm, K, V, compare, hash, allocator)\
-    _flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), compare, hash, allocator)
+#define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\
+    _flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)
 
 FLECS_DBG_API
 void flecs_hashmap_fini(


### PR DESCRIPTION
I used some features of flecs in my program, and I noticed a small mistake in the parameter naming. as follows:

`#define flecs_hashmap_init(hm, K, V, compare, hash, allocator)\ 
_flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), compare, hash, allocator)`

`#define flecs_hashmap_init(hm, K, V, hash, compare, allocator)\ 
_flecs_hashmap_init(hm, ECS_SIZEOF(K), ECS_SIZEOF(V), hash, compare, allocator)`